### PR TITLE
Fix invalid connection string issue on strings without env vars

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,21 +102,15 @@ async function deleteAccounts(client, callback) {
 (async () => {
   prompt.start();
   const URI = await prompt.get("connectionString");
-  var connectionString;
-  // Expand $env:appdata environment variable in Windows connection string
-  if (URI.connectionString.includes("env:appdata")) {
-    connectionString = await URI.connectionString.replace(
-      "$env:appdata",
-      process.env.APPDATA
-    );
-  }
-  // Expand $HOME environment variable in UNIX connection string
-  else if (URI.connectionString.includes("HOME")){
-    connectionString = await URI.connectionString.replace(
-      "$HOME",
-      process.env.HOME
-    );
-  }
+  const connectionString = URI.connectionString.replace(
+    // Expand $env:appdata environment variable in Windows connection string
+    "$env:appdata",
+    process.env.APPDATA
+  ).replace(
+    // Expand $HOME environment variable in UNIX connection string
+    "$HOME",
+    process.env.HOME
+  );
   var config = parse(connectionString);
   config.port = 26257;
   config.database = "bank";


### PR DESCRIPTION
If one supplies a `connectionString` without $env:appdata or $HOME env vars, such as `postgresql://root@localhost:26257/defaultdb?sslmode=disable`, the program fails to run:

```
(base) dannycho7@MacBook-Pro-3 cockroachdb-benchmark % node app.js
prompt: connectionString:  postgresql://root@MacBook-Pro-3:26257/defaultdb?sslmode=disable
TypeError: Cannot read properties of undefined (reading 'charAt')
    at parse (/Users/dannycho7/Documents/Code/apiary/cockroachdb-benchmark/node_modules/pg-connection-string/index.js:13:11)
    at /Users/dannycho7/Documents/Code/apiary/cockroachdb-benchmark/app.js:120:16
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

This PR fixes this issue, alongside consolidating the `replace` procedures for readability.